### PR TITLE
conference paper metadata uses "chapter-url"

### DIFF
--- a/Template.php
+++ b/Template.php
@@ -2287,14 +2287,14 @@ final class Template {
       }
     }
     if ($new_name === 'cite book') {
-            // all open-access versions of conference papers point to the paper itself
-            // not to the whole proceedings
-            // so we use chapter-url so that the template is well rendered afterwards
-            if ($this->blank('chapter-url')) {
-              $this->rename('url', 'chapter-url');
-            } elseif (0 === strcasecmp($this->get('chapter'), $this->get('url'))) {
-              $this->forget('url');
-            }  // otherwise they are differnt urls
+      // all open-access versions of conference papers point to the paper itself
+      // not to the whole proceedings
+      // so we use chapter-url so that the template is well rendered afterwards
+      if ($this->blank('chapter-url')) {
+        $this->rename('url', 'chapter-url');
+      } elseif (0 === strcasecmp($this->get('chapter-url'), $this->get('url'))) {
+        $this->forget('url');
+      }  // otherwise they are differnt urls
     }
   }
   
@@ -2567,7 +2567,7 @@ final class Template {
      
         case 'chapter-url':
           if ($this->blank(['url', 'chapter'])) {
-            $this-rename('chapter-url', 'url');
+            $this->rename('chapter-url', 'url');
             $param = 'url'; // passes down to next area
           }
         case 'url':

--- a/Template.php
+++ b/Template.php
@@ -268,7 +268,7 @@ final class Template {
             // all open-access versions of conference papers point to the paper itself
             // not to the whole proceedings
             // so we use chapter-url so that the template is well rendered afterwards
-            if ($this->blank('chapter-url') {
+            if ($this->blank('chapter-url')) {
               $this->rename('url', 'chapter-url');
             } elseif (0 === strcasecmp($this->get('chapter'), $this->get('url'))) {
               $this->forget('url');

--- a/Template.php
+++ b/Template.php
@@ -264,15 +264,6 @@ final class Template {
           // Convert from journal to book, if there is a unique chapter name or has an ISBN
           if ($this->has('chapter') && ($this->wikiname() == 'cite journal') && ($this->get('chapter') != $this->get('title') || $this->has('isbn'))) { 
             $this->change_name_to('Cite book');
-            
-            // all open-access versions of conference papers point to the paper itself
-            // not to the whole proceedings
-            // so we use chapter-url so that the template is well rendered afterwards
-            if ($this->blank('chapter-url')) {
-              $this->rename('url', 'chapter-url');
-            } elseif (0 === strcasecmp($this->get('chapter'), $this->get('url'))) {
-              $this->forget('url');
-            }  // otherwise they are differnt urls
           }
           break;
       }
@@ -2295,6 +2286,16 @@ final class Template {
           break;
       }
     }
+    if ($new_name === 'cite book') {
+            // all open-access versions of conference papers point to the paper itself
+            // not to the whole proceedings
+            // so we use chapter-url so that the template is well rendered afterwards
+            if ($this->blank('chapter-url')) {
+              $this->rename('url', 'chapter-url');
+            } elseif (0 === strcasecmp($this->get('chapter'), $this->get('url'))) {
+              $this->forget('url');
+            }  // otherwise they are differnt urls
+    }
   }
   
   public function wikiname() {
@@ -2565,7 +2566,7 @@ final class Template {
           return;
      
         case 'chapter-url':
-          if ($this->blank(['url', 'chapter']) {
+          if ($this->blank(['url', 'chapter'])) {
             $this-rename('chapter-url', 'url');
             $param = 'url'; // passes down to next area
           }

--- a/Template.php
+++ b/Template.php
@@ -2385,11 +2385,6 @@ final class Template {
             if (!strcasecmp($this->get($param), $this->get('work'))) $this->forget('work');
             if (!strcasecmp($this->get('chapter'), $this->get('title'))) {
               $this->forget('chapter');
-              if ($this->blank('url') && $this->has('chapter-url')) {
-                $this->rename('chapter-url', 'url');
-              } elseif ($this->blank('url') && $this->has('chapterurl')) {
-                $this->rename('chapterurl', 'url');
-              }  
               return; // Nonsense to have both.
             }
           }
@@ -2690,11 +2685,6 @@ final class Template {
             $this->forget('title');
         } elseif ($this->wikiname() === 'cite journal' || $this->wikiname() === 'citation') {
           $this->forget('chapter');
-          if ($this->blank('url') && $this->has('chapter-url')) {
-            $this->rename('chapter-url', 'url');
-          } elseif ($this->blank('url') && $this->has('chapterurl')) {
-            $this->rename('chapterurl', 'url');
-          }
         }
       }
       // Sometimes series and journal come from different databases
@@ -3069,6 +3059,13 @@ final class Template {
       $this->forgetter('via', $echo_forgetting);
       $this->forgetter('website', $echo_forgetting);
       $this->forgetter('deadurl', $echo_forgetting);
+    }
+    if ($par == 'chapter' && $this->blank('url')) {
+      if($this->has('chapter-url')) {
+        $this->rename('chapter-url', 'url');
+      } elseif ($this->has('chapterurl')) {
+        $this->rename('chapterurl', 'url');
+      }
     }
     $pos = $this->get_param_key($par);
     if ($pos !== NULL) {

--- a/Template.php
+++ b/Template.php
@@ -2684,7 +2684,7 @@ final class Template {
         if ($this->wikiname() === 'cite book' || $this->has('isbn')) {
             $this->forget('title');
         } elseif ($this->wikiname() === 'cite journal' || $this->wikiname() === 'citation') {
-          $this->forget('chapter');
+          $this->forget('chapter'); 
         }
       }
       // Sometimes series and journal come from different databases

--- a/Template.php
+++ b/Template.php
@@ -2384,7 +2384,7 @@ final class Template {
           if ($this->has('chapter')) {
             if (!strcasecmp($this->get($param), $this->get('work'))) $this->forget('work');
             if (!strcasecmp($this->get('chapter'), $this->get('title'))) {
-              $this->forget('chapter');
+              $this->forget('chapter'); 
               return; // Nonsense to have both.
             }
           }
@@ -2684,7 +2684,7 @@ final class Template {
         if ($this->wikiname() === 'cite book' || $this->has('isbn')) {
             $this->forget('title');
         } elseif ($this->wikiname() === 'cite journal' || $this->wikiname() === 'citation') {
-          $this->forget('chapter'); 
+          $this->forget('chapter');
         }
       }
       // Sometimes series and journal come from different databases

--- a/Template.php
+++ b/Template.php
@@ -264,6 +264,11 @@ final class Template {
           // Convert from journal to book, if there is a unique chapter name or has an ISBN
           if ($this->has('chapter') && ($this->wikiname() == 'cite journal') && ($this->get('chapter') != $this->get('title') || $this->has('isbn'))) { 
             $this->change_name_to('Cite book');
+            
+            // all open-access versions of conference papers point to the paper itself
+            // not to the whole proceedings
+            // so we use chapter-url so that the template is well rendered afterwards
+            $this->rename('url', 'chapter-url');
           }
           break;
       }

--- a/Template.php
+++ b/Template.php
@@ -2387,7 +2387,9 @@ final class Template {
               $this->forget('chapter');
               if ($this->blank('url') && $this->has('chapter-url')) {
                 $this->rename('chapter-url', 'url');
-              }   
+              } elseif ($this->blank('url') && $this->has('chapterurl')) {
+                $this->rename('chapterurl', 'url');
+              }  
               return; // Nonsense to have both.
             }
           }
@@ -2569,8 +2571,9 @@ final class Template {
           return;
      
         case 'chapter-url':
+        case 'chapterurl':
           if ($this->blank(['url', 'chapter'])) {
-            $this->rename('chapter-url', 'url');
+            $this->rename($param, 'url');
             $param = 'url'; // passes down to next area
           }
         case 'url':
@@ -2689,6 +2692,8 @@ final class Template {
           $this->forget('chapter');
           if ($this->blank('url') && $this->has('chapter-url')) {
             $this->rename('chapter-url', 'url');
+          } elseif ($this->blank('url') && $this->has('chapterurl')) {
+            $this->rename('chapterurl', 'url');
           }
         }
       }

--- a/Template.php
+++ b/Template.php
@@ -2384,7 +2384,10 @@ final class Template {
           if ($this->has('chapter')) {
             if (!strcasecmp($this->get($param), $this->get('work'))) $this->forget('work');
             if (!strcasecmp($this->get('chapter'), $this->get('title'))) {
-              $this->forget('chapter'); 
+              $this->forget('chapter');
+              if ($this->blank('url') && $this->has('chapter-url')) {
+                $this->rename('chapter-url', 'url');
+              }   
               return; // Nonsense to have both.
             }
           }
@@ -2684,6 +2687,9 @@ final class Template {
             $this->forget('title');
         } elseif ($this->wikiname() === 'cite journal' || $this->wikiname() === 'citation') {
           $this->forget('chapter');
+          if ($this->blank('url') && $this->has('chapter-url')) {
+            $this->rename('chapter-url', 'url');
+          }
         }
       }
       // Sometimes series and journal come from different databases

--- a/Template.php
+++ b/Template.php
@@ -2290,7 +2290,7 @@ final class Template {
       // all open-access versions of conference papers point to the paper itself
       // not to the whole proceedings
       // so we use chapter-url so that the template is well rendered afterwards
-      if ($this->blank('chapter-url') && $this->has('chapter')) {
+      if ($this->blank(['chapter-url','chapterurl']) && $this->has('chapter')) {
         $this->rename('url', 'chapter-url');
       } elseif (0 === strcasecmp($this->get('chapter-url'), $this->get('url'))) {
         $this->forget('url');

--- a/Template.php
+++ b/Template.php
@@ -2564,7 +2564,12 @@ final class Template {
           if ($title && !strcasecmp($this->get($param), $this->get('work'))) $this->forget('work');
           return;
      
-        case 'url': case 'chapter-url':
+        case 'chapter-url':
+          if ($this->blank(['url', 'chapter']) {
+            $this-rename('chapter-url', 'url');
+            $param = 'url'; // passes down to next area
+          }
+        case 'url':
           if (preg_match("~^https?://(?:www.|)researchgate.net/[^\s]*publication/([0-9]+)_*~i", $this->get($param), $matches)) {
               $this->set($param, 'https://www.researchgate.net/publication/' . $matches[1]);
           } elseif (preg_match("~^https?://(?:www.|)academia.edu/([0-9]+)/*~i", $this->get($param), $matches)) {

--- a/Template.php
+++ b/Template.php
@@ -268,7 +268,11 @@ final class Template {
             // all open-access versions of conference papers point to the paper itself
             // not to the whole proceedings
             // so we use chapter-url so that the template is well rendered afterwards
-            $this->rename('url', 'chapter-url');
+            if ($this->blank('chapter-url') {
+              $this->rename('url', 'chapter-url');
+            } elseif (0 === strcasecmp($this->get('chapter'), $this->get('url'))) {
+              $this->forget('url');
+            }  // otherwise they are differnt urls
           }
           break;
       }

--- a/Template.php
+++ b/Template.php
@@ -2290,7 +2290,7 @@ final class Template {
       // all open-access versions of conference papers point to the paper itself
       // not to the whole proceedings
       // so we use chapter-url so that the template is well rendered afterwards
-      if ($this->blank('chapter-url')) {
+      if ($this->blank('chapter-url') && $this->has('chapter')) {
         $this->rename('url', 'chapter-url');
       } elseif (0 === strcasecmp($this->get('chapter-url'), $this->get('url'))) {
         $this->forget('url');

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -231,7 +231,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $expanded = $this->process_citation($text);
     $this->assertEquals('978-0470016176', $expanded->get('isbn'));
     $this->assertEquals('cite book', $expanded->wikiname());
-    $this->assertEquals('http://www.paulselden.net/uploads/7/5/3/2/7532217/elsterrestrialization.pdf', $this->get('chapter-url'));
+    $this->assertEquals('http://www.paulselden.net/uploads/7/5/3/2/7532217/elsterrestrialization.pdf', $expanded->get('chapter-url'));
     $this->assertNull($expanded->get('url'));
   }
 

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -231,7 +231,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $expanded = $this->process_citation($text);
     $this->assertEquals('9780781765626', $expanded->get('isbn'));
     $this->assertEquals('cite book', $expanded->wikiname());
-    $this->assertEquals('http://www.paulselden.net/uploads/7/5/3/2/7532217/elsterrestrialization.pdf', $this->get('chapter-url');
+    $this->assertEquals('http://www.paulselden.net/uploads/7/5/3/2/7532217/elsterrestrialization.pdf', $this->get('chapter-url'));
     $this->assertNull($expanded->get('url'));
   }
 

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -229,7 +229,7 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
   public function testTemplateRenamingURLConvert() {
     $text='{{cite journal |url=http://www.paulselden.net/uploads/7/5/3/2/7532217/elsterrestrialization.pdf |title=Terrestrialization (Precambrian–Devonian) |last=Selden |first=Paul A. |year=2005 |encyclopedia=[[Encyclopedia of Life Sciences]] |publisher=[[John Wiley & Sons, Ltd.]] |doi=10.1038/npg.els.0004145 |format=PDF}}';
     $expanded = $this->process_citation($text);
-    $this->assertEquals('9780781765626', $expanded->get('isbn'));
+    $this->assertEquals('978-0470016176', $expanded->get('isbn'));
     $this->assertEquals('cite book', $expanded->wikiname());
     $this->assertEquals('http://www.paulselden.net/uploads/7/5/3/2/7532217/elsterrestrialization.pdf', $this->get('chapter-url'));
     $this->assertNull($expanded->get('url'));

--- a/tests/phpunit/TemplateTest.php
+++ b/tests/phpunit/TemplateTest.php
@@ -226,6 +226,15 @@ final class TemplateTest extends PHPUnit\Framework\TestCase {
     $this->assertEquals('cite book', $expanded->wikiname());
   }
   
+  public function testTemplateRenamingURLConvert() {
+    $text='{{cite journal |url=http://www.paulselden.net/uploads/7/5/3/2/7532217/elsterrestrialization.pdf |title=Terrestrialization (Precambrian–Devonian) |last=Selden |first=Paul A. |year=2005 |encyclopedia=[[Encyclopedia of Life Sciences]] |publisher=[[John Wiley & Sons, Ltd.]] |doi=10.1038/npg.els.0004145 |format=PDF}}';
+    $expanded = $this->process_citation($text);
+    $this->assertEquals('9780781765626', $expanded->get('isbn'));
+    $this->assertEquals('cite book', $expanded->wikiname());
+    $this->assertEquals('http://www.paulselden.net/uploads/7/5/3/2/7532217/elsterrestrialization.pdf', $this->get('chapter-url');
+    $this->assertNull($expanded->get('url'));
+  }
+
   public function testDoiExpansion() {
     $text = "{{Cite web | http://onlinelibrary.wiley.com/doi/10.1111/j.1475-4983.2012.01203.x/abstract}}";
     $prepared = $this->prepare_citation($text);


### PR DESCRIPTION
Changes implemented in this pull request:
- for conference papers, the `url` field is changed to `chapter-url`, because most open-access versions of conference papers point to the paper itself, and not to the whole proceedings